### PR TITLE
Add HPOS support with backward compatibility

### DIFF
--- a/conversion-tracking.php
+++ b/conversion-tracking.php
@@ -372,12 +372,3 @@ wcct_init();
 function wcct_manage_cap() {
     return apply_filters( 'wcct_capability', 'manage_options' );
 }
-
-/**
- * Check if HPOS is enabled
- *
- * @return bool
- */
-function wcct_is_hpos_enabled() {
-    return class_exists( \Automattic\WooCommerce\Utilities\OrderUtil::class ) && \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
-}

--- a/conversion-tracking.php
+++ b/conversion-tracking.php
@@ -259,8 +259,10 @@ class WeDevs_WC_Conversion_Tracking {
 
 	/**
 	 * Add High Performance Order Storage Support
+     *
+     * @see https://developer.woocommerce.com/docs/hpos-extension-recipe-book/
 	 *
-	 * @since 2.0.11
+	 * @since 2.1.0
 	 *
 	 * @return void
 	 */

--- a/conversion-tracking.php
+++ b/conversion-tracking.php
@@ -78,8 +78,9 @@ class WeDevs_WC_Conversion_Tracking {
         $this->init_classes();
 
         register_activation_hook( __FILE__, array( $this, 'activate' ) );
-        // hpos support
-	    add_action( 'before_woocommerce_init', [ $this, 'add_hpos_support' ] );
+
+        // Add High Performance Order Storage Support
+        add_action( 'before_woocommerce_init', [ $this, 'declare_woocommerce_feature_compatibility' ] );
 
         do_action( 'wcct_loaded' );
     }
@@ -263,7 +264,7 @@ class WeDevs_WC_Conversion_Tracking {
 	 *
 	 * @return void
 	 */
-	public function add_hpos_support() {
+	public function declare_woocommerce_feature_compatibility() {
 		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
 			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
             \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__, true );
@@ -345,7 +346,7 @@ class WeDevs_WC_Conversion_Tracking {
                 </div>
                 <div class="wcct-message-action">
                     <a href="" id="wcct-install-happ-addons" class="button button-primary"> <i class="dashicons dashicons-update wcct-update-icon"></i> Install Now For FREE</a>
-                    <p></strong><a target="_blank" href="https://wordpress.org/plugins/happy-elementor-addons/">Read more details ➔</a>
+                    <p><a target="_blank" href="https://wordpress.org/plugins/happy-elementor-addons/">Read more details ➔</a>
                     </p>
                 </div>
             </div>
@@ -364,8 +365,17 @@ wcct_init();
 /**
  * Manage Capability
  *
- * @return void
+ * @return string
  */
 function wcct_manage_cap() {
     return apply_filters( 'wcct_capability', 'manage_options' );
+}
+
+/**
+ * Check if HPOS is enabled
+ *
+ * @return bool
+ */
+function wcct_is_hpos_enabled() {
+    return class_exists( \Automattic\WooCommerce\Utilities\OrderUtil::class ) && \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
 }

--- a/includes/class-abstract-integration.php
+++ b/includes/class-abstract-integration.php
@@ -80,7 +80,7 @@ abstract class WCCT_Integration {
     public function is_enabled() {
         $settings = $this->get_integration_settings();
 
-        if ( $settings && $settings[ 'enabled' ] === true ) {
+        if ( $settings && (boolean) $settings[ 'enabled' ] ) {
             return true;
         }
 

--- a/includes/class-abstract-integration.php
+++ b/includes/class-abstract-integration.php
@@ -80,7 +80,7 @@ abstract class WCCT_Integration {
     public function is_enabled() {
         $settings = $this->get_integration_settings();
 
-        if ( $settings && $settings[ 'enabled' ] == true ) {
+        if ( $settings && $settings[ 'enabled' ] === true ) {
             return true;
         }
 
@@ -106,8 +106,6 @@ abstract class WCCT_Integration {
 
     /**
      * Integration settings get options
-     *
-     * @param  string $integration_id
      *
      * @return array|false
      */

--- a/includes/class-abstract-integration.php
+++ b/includes/class-abstract-integration.php
@@ -80,7 +80,7 @@ abstract class WCCT_Integration {
     public function is_enabled() {
         $settings = $this->get_integration_settings();
 
-        if ( $settings && (boolean) $settings[ 'enabled' ] ) {
+        if ( $settings && wc_string_to_bool($settings[ 'enabled' ]) ) {
             return true;
         }
 

--- a/includes/class-integration-manager.php
+++ b/includes/class-integration-manager.php
@@ -38,7 +38,7 @@ class WCCT_Integration_Manager {
     /**
      * Get all active integrations
      *
-     * @return void
+     * @return array
      */
     public function get_active_integrations() {
         $integrations = $this->integrations;
@@ -56,7 +56,7 @@ class WCCT_Integration_Manager {
     /**
      * Get all integration
      *
-     * @return array
+     * @return array|void
      */
     public function get_integrations() {
         if ( empty( $this->integrations ) ) {

--- a/includes/class-integration-manager.php
+++ b/includes/class-integration-manager.php
@@ -56,11 +56,11 @@ class WCCT_Integration_Manager {
     /**
      * Get all integration
      *
-     * @return array|void
+     * @return array
      */
     public function get_integrations() {
         if ( empty( $this->integrations ) ) {
-            return;
+	        return array();
         }
 
         return $this->integrations;

--- a/includes/integration.php
+++ b/includes/integration.php
@@ -267,11 +267,7 @@ class WeDevs_WC_Tracking_Integration extends WC_Integration {
             return '';
         }
 
-        if ( wcct_is_hpos_enabled() ) {
-            return $product->get_meta( '_wc_conv_track' );
-        } else {
-            return get_post_meta( $product_id, '_wc_conv_track', true );
-        }
+	    return $product->get_meta( '_wc_conv_track' );
     }
 
 
@@ -345,7 +341,7 @@ class WeDevs_WC_Tracking_Integration extends WC_Integration {
         }
 
         $customer       = $order->get_user();
-        $used_coupons   = implode( ',', $order->$used_coupons() );
+        $used_coupons   = implode( ',', $used_coupons );
         $order_total    = $order->get_total();
         $order_number   = $order->get_order_number();
         $order_subtotal = $order->get_subtotal();

--- a/includes/integration.php
+++ b/includes/integration.php
@@ -112,15 +112,11 @@ class WeDevs_WC_Tracking_Integration extends WC_Integration {
         if ( isset( $_POST['_wc_conv_track'] ) ) {
             $value = trim( sanitize_text_field( wp_unslash( $_POST['_wc_conv_track'] ) ) );
 
-            if ( wcct_is_hpos_enabled() ) {
-                $product = wc_get_product( $post_id );
-                if ( $product ) {
-                    $product->update_meta_data( '_wc_conv_track', $value );
-                    $product->save();
-                }
-            } else {
-                update_post_meta( $post_id, '_wc_conv_track', $value );
-            }
+	        $product = wc_get_product( $post_id );
+	        if ( $product ) {
+		        $product->update_meta_data( '_wc_conv_track', $value );
+		        $product->save();
+	        }
         }
     }
 
@@ -232,8 +228,6 @@ class WeDevs_WC_Tracking_Integration extends WC_Integration {
      */
     public function thankyou_page( $order_id ) {
         $order = wc_get_order( $order_id );
-
-        error_log( print_r( $order, true ) );
 
         if ( ! $order ) {
             return;

--- a/includes/integrations/class-integration-custom.php
+++ b/includes/integrations/class-integration-custom.php
@@ -107,24 +107,30 @@ class WCCT_Integration_Custom extends WCCT_Integration {
             return $code;
         }
 
-        if ( version_compare( WC()->version, '3.0', '<' ) ) {
-            // older version
+        if ( version_compare( WC()->version, '3.0', '<=' ) ) {
             $order_currency = $order->get_order_currency();
             $payment_method = $order->payment_method;
+            $order_shipping = $order->get_total_shipping();
 
         } else {
             $order_currency = $order->get_currency();
             $payment_method = $order->get_payment_method();
+            $order_shipping = $order->get_shipping_total();
+        }
+
+        if ( version_compare( WC()->version, '3.7', '<=' ) ) {
+            $used_coupons = $order->get_used_coupons();
+
+        } else {
+            $used_coupons = $order->get_coupon_codes();
         }
 
         $customer       = $order->get_user();
-        $used_coupons   = $order->get_used_coupons() ? implode( ',', $order->get_used_coupons() ) : '';
-        $order_currency = $order_currency;
-        $order_total    = $order->get_total() ? $order->get_total() : 0;
+        $used_coupons   = implode( ',', $used_coupons );
+        $order_total    = $order->get_total();
         $order_number   = $order->get_order_number();
         $order_subtotal = $order->get_subtotal();
 	    $order_discount = $order->get_total_discount();
-	    $order_shipping = $order->get_total_shipping();
 
 
         // customer details


### PR DESCRIPTION
### Closes 
* Closes https://github.com/getdokan/woocommerce-conversion-tracking/issues/45



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced compatibility declarations for WooCommerce features, including HPOS support.
	- Introduced a new function to check if HPOS is enabled.
	- Updated integration manager to include additional integrations and clarified return types for methods.

- **Bug Fixes**
	- Refined order processing logic to ensure compatibility with various WooCommerce versions.

- **Documentation**
	- Updated method return types for better clarity and type safety.

- **Refactor**
	- Streamlined conversion tracking code handling and improved method structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->